### PR TITLE
Unharcode icon path and file type

### DIFF
--- a/v4l2_wayland.desktop
+++ b/v4l2_wayland.desktop
@@ -4,6 +4,6 @@ Encoding=UTF-8
 Name=V4L2 Wayland
 Comment=A computer vision musical instrument
 Exec=v4l2_wayland
-Icon=/usr/share/icons/hicolor/scalable/apps/v4l2_wayland.svg
+Icon=v4l2_wayland
 Categories=AudioVideo
 Terminal=false


### PR DESCRIPTION
Since you install the icon to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the icon path + file extension in the `.desktop` launcher. It will be found anyway.

This facilitates icon theming and the automated use of differently sized icons (if provided in ``hicolor/<size>/apps``).
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).